### PR TITLE
Run sim in a tighter loop when in not rendering

### DIFF
--- a/cawro.js
+++ b/cawro.js
@@ -701,7 +701,12 @@ function toggleDisplay() {
   if(doDraw) {
     doDraw = false;
     cw_stopSimulation();
-    cw_runningInterval = setInterval(simulationStep, 1); // simulate 1000x per second when not drawing
+    cw_runningInterval = setInterval(function() {
+      var time = performance.now() + (1000 / screenfps);
+      while (time > performance.now()) {
+        simulationStep();
+      }
+    }, 1);
   } else {
     doDraw = true;
     clearInterval(cw_runningInterval);


### PR DESCRIPTION
Makes the sim run about 2-3x faster as a 1ms interval is not as performant as a loop.
