### PR TITLE
kill car when it reaches and of the path

### DIFF
--- a/cawro.js
+++ b/cawro.js
@@ -213,6 +213,11 @@ cw_Car.prototype.kill = function() {
 cw_Car.prototype.checkDeath = function() {
   // check health
   var position = this.getPosition();
+  // check if car reached end of the path
+  if(position.x > world.finishLine) {
+      this.healthBar.width = "0";
+      return true;
+  }
   if(position.y > this.maxPositiony) {
     this.maxPositiony = position.y;
   }

--- a/path.js
+++ b/path.js
@@ -19,6 +19,7 @@ function cw_createFloor() {
     last_world_coords = last_tile.GetWorldPoint(last_fixture.GetShape().m_vertices[3]);
     tile_position = last_world_coords;
   }
+  world.finishLine = tile_position.x;
 }
 
 


### PR DESCRIPTION
Instead of falling off from last tile of the path, this patch makes simulation
kill the car and record last position achieved by it.

Signed-off-by: Maciej Kisielewski <kissiel@gmail.com>