### PR TITLE
Make initial random seed derive from initial text in seed textbox, rather than random value

### DIFF
--- a/cawro.js
+++ b/cawro.js
@@ -87,6 +87,8 @@ var cw_ghostReplayInterval = null;
 
 var distanceMeter = document.getElementById("distancemeter");
 
+var floorseed;
+
 var leaderPosition = new Object();
 leaderPosition.x = 0;
 leaderPosition.y = 0;
@@ -1030,7 +1032,8 @@ function cw_init() {
   }
   mmm.parentNode.removeChild(mmm);
   hbar.parentNode.removeChild(hbar);
-  floorseed = btoa(Math.seedrandom());
+  floorseed = document.getElementById("newseed").value;
+  Math.seedrandom(floorseed);
   world = new b2World(gravity, doSleep);
   cw_createFloor();
   cw_drawMiniMap();


### PR DESCRIPTION
When initialising, a random seed is chosen randomly, however when resetting the world the random seed is derived from the content of the random seed text box.

This change makes things more consistent, such that the random seed is always derived from the content of the random seed text box regardless of whether we are resetting or initialising.
